### PR TITLE
Suggestion to limit the perceived scope of the dip

### DIFF
--- a/DIPs/DIP1021.md
+++ b/DIPs/DIP1021.md
@@ -20,8 +20,10 @@ function doesn't allow the reference to escape.
 
 But if a function is passed more than one reference to the same container,
 one reference can render invalid the data referred to by the other reference(s).
-This DIP aims to correct that problem. It's a natural progression after
-DIP 25 and DIP 1000 which is needed to safely implement Reference Counting.
+
+This DIP aims to reduce the occurance of that problem by making it a compile time error to
+explicitly pass two refernces to the same memory to a function in @safe code. It's a natural 
+progression after DIP 25 and DIP 1000 which is needed to safely implement Reference Counting.
 
 ## Contents
 * [Rationale](#rationale)


### PR DESCRIPTION
I would also suggest to have an example that compiles today with `@safe` that would be rendered uncompilable in `@safe` code by this dip. I believe it will greatly reduce confusion on the scope.